### PR TITLE
Fix license

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ test:
 about:
   home: http://bitbucket.org/brandon/backports.ssl_match_hostname
   license:  PSF 2
+  license_file: backports/ssl_match_hostname/LICENSE.txt
   summary: 'The ssl.match_hostname() function from Python 3.5'
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ test:
 
 about:
   home: http://bitbucket.org/brandon/backports.ssl_match_hostname
-  license:  Python Software Foundation License
+  license:  PSF 2
   summary: 'The ssl.match_hostname() function from Python 3.5'
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 502ad98707319f4a51fa2ca1c677bd659008d27ded9f6380c79e8932e38dcdf2
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install
   skip: True  # [py>=35]
 


### PR DESCRIPTION
Fixes the lint [issue]( https://github.com/conda-forge/ssl_match_hostname-feedstock/pull/5#issuecomment-283219430 ). Adds the license version. Also packages the license.